### PR TITLE
Support pip via conda

### DIFF
--- a/conf/sample-team-conf.yaml
+++ b/conf/sample-team-conf.yaml
@@ -93,3 +93,9 @@ apps:
     type: conda
     package: anaconda-project
     executable_path: bin/anaconda-project
+  conan:
+    version: 1.20.4
+    relocatable: false
+    type: pip
+    package: conan
+    executable_path: bin/conan

--- a/ozy/installer.py
+++ b/ozy/installer.py
@@ -2,7 +2,7 @@ from ozy import OzyError
 
 
 class Installer:
-    def __init__(self, name, config, *required_keys, **default_keys):
+    def __init__(self, name: str, config: dict, *required_keys, **default_keys):
         self._name = name
         self._config = default_keys.copy()
         for required_key in required_keys:
@@ -13,10 +13,10 @@ class Installer:
             if optional_key in config:
                 self._config[optional_key] = config[optional_key]
 
-    def config(self, name):
+    def config(self, name) -> object:
         return self._config[name]
 
-    def install(self, to_dir):
+    def install(self, to_dir: str):
         raise RuntimeError("Must be overridden")
 
 # TODO tests for installers!

--- a/ozy/installers/__init__.py
+++ b/ozy/installers/__init__.py
@@ -1,5 +1,6 @@
 from ozy.installers.conda import CondaInstaller
 from ozy.installers.file import SingleFileInstaller
+from ozy.installers.pip import PipInstaller
 from ozy.installers.shell import ShellInstaller
 from ozy.installers.tar import TarballInstaller
 from ozy.installers.zip import SingleBinaryZipInstaller
@@ -9,5 +10,6 @@ SUPPORTED_INSTALLERS = dict(
     tarball=TarballInstaller,
     single_file=SingleFileInstaller,
     shell_install=ShellInstaller,
-    conda=CondaInstaller
+    conda=CondaInstaller,
+    pip=PipInstaller
 )

--- a/ozy/installers/pip.py
+++ b/ozy/installers/pip.py
@@ -1,0 +1,29 @@
+import logging
+import os
+from subprocess import check_call
+
+from ozy.installer import Installer
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PipInstaller(Installer):
+    def __init__(self, name, config):
+        super().__init__(name, config, 'package', 'version', channels=[])
+
+    def __str__(self):
+        return f'pip app installer for {self.config("package")}'
+
+    def install(self, to_dir):
+        os.makedirs(to_dir)
+        channels = []
+        for channel in self.config('channels'):
+            channels += ['-c', channel]
+        # Create a conda environment with pip installed (which brings in python et al)
+        args = ['conda', 'create', '-y'] + channels + ['-p', to_dir, 'pip']
+        _LOGGER.debug("Executing %s", " ".join(args))
+        check_call(args)
+        # Use that environment to pip install the user's package
+        args = [os.path.join(to_dir, 'bin', 'pip'), 'install', f'{self.config("package")}=={self.config("version")}']
+        _LOGGER.debug("Executing %s", " ".join(args))
+        check_call(args)

--- a/test/unit/installers/test_pip.py
+++ b/test/unit/installers/test_pip.py
@@ -1,0 +1,31 @@
+from unittest import mock
+
+import pytest
+
+from ozy import OzyError
+from ozy.installers.pip import PipInstaller
+
+
+def test_raises_on_missing_keys():
+    with pytest.raises(OzyError):
+        PipInstaller('test', dict())
+    with pytest.raises(OzyError):
+        PipInstaller('test', dict(package='p'))
+    with pytest.raises(OzyError):
+        PipInstaller('test', dict(version='123'))
+
+
+def test_constructs_ok_with_correct_config():
+    PipInstaller('test', dict(package='p', version='123'))
+
+
+@mock.patch('ozy.installers.pip.os.makedirs')
+@mock.patch('ozy.installers.pip.check_call')
+def test_installs(mock_check_call, mock_makedirs):
+    installer = PipInstaller('test', dict(package='package', version='1.0.0'))
+    installer.install('/some/directory')
+    mock_makedirs.assert_called_with('/some/directory')
+    mock_check_call.assert_has_calls([
+        mock.call(['conda', 'create', '-y', '-p', '/some/directory', 'pip']),
+        mock.call(['/some/directory/bin/pip', 'install', 'package==1.0.0'])
+    ])

--- a/test/unit/test_installer.py
+++ b/test/unit/test_installer.py
@@ -1,0 +1,34 @@
+import pytest
+
+from ozy import OzyError
+from ozy.installer import Installer
+
+
+def test_empty_dict_is_ok():
+    Installer('test', dict())
+
+
+def test_drops_non_specified_keys():
+    installer = Installer('test', dict(not_mentioned='123'))
+    with pytest.raises(KeyError):
+        installer.config('not_mentioned')
+
+
+def test_accepts_non_required_keys():
+    installer = Installer('test', dict(optional_key='opt'), optional_key='some default')
+    assert installer.config('optional_key') == 'opt'
+
+
+def test_defaults_non_required_keys():
+    installer = Installer('test', dict(), optional_key='some default')
+    assert installer.config('optional_key') == 'some default'
+
+
+def test_accepts_required_keys():
+    installer = Installer('test', dict(version='1.2.3'), 'version')
+    assert installer.config('version') == '1.2.3'
+
+
+def test_throws_on_missing_required_keys():
+    with pytest.raises(OzyError, match='Missing required key.*not_there.*in.*test.*'):
+        Installer('test', dict(), 'not_there')


### PR DESCRIPTION
Adds beginnings of tests for installers too. Adds example of installing `conan` via pip.