### PR TITLE
Teach `ozy` to handle `zip` archives

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # ozy release notes
 
+## 0.0.6
+* Add support for `zip` file releases
+
 ## 0.0.5
 * Add support for `pip` installers (via `conda`).
 

--- a/ozy/__init__.py
+++ b/ozy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.5'
+__version__ = '0.0.6'
 import logging
 
 _LOGGER = logging.getLogger(__name__)

--- a/ozy/installers/__init__.py
+++ b/ozy/installers/__init__.py
@@ -3,10 +3,11 @@ from ozy.installers.file import SingleFileInstaller
 from ozy.installers.pip import PipInstaller
 from ozy.installers.shell import ShellInstaller
 from ozy.installers.tar import TarballInstaller
-from ozy.installers.zip import SingleBinaryZipInstaller
+from ozy.installers.zip import SingleBinaryZipInstaller, ZipInstaller
 
 SUPPORTED_INSTALLERS = dict(
     single_binary_zip=SingleBinaryZipInstaller,
+    zip=ZipInstaller,
     tarball=TarballInstaller,
     single_file=SingleFileInstaller,
     shell_install=ShellInstaller,

--- a/ozy/installers/zip.py
+++ b/ozy/installers/zip.py
@@ -13,7 +13,7 @@ class SingleBinaryZipInstaller(Installer):
         super().__init__(name, config, 'url', app_name=name)
 
     def __str__(self):
-        return f'zip installer from {self.config("url")}'
+        return f'single_binary_zip installer from {self.config("url")}'
 
     def install(self, to_dir):
         app_name = self.config('app_name')
@@ -31,3 +31,23 @@ class SingleBinaryZipInstaller(Installer):
                 with zf.open(contents[0]) as in_file:
                     out_file.write(in_file.read())
             os.chmod(app_path, 0o774)
+
+
+class ZipInstaller(Installer):
+    def __init__(self, name, config):
+        super().__init__(name, config, 'url')
+        self.executable_path = config.get('executable_path', name)
+
+    def __str__(self):
+        return f'zip installer from {self.config("url")}'
+
+    def install(self, to_dir):
+        os.makedirs(to_dir)
+        url = self.config('url')
+        with NamedTemporaryFile() as temp_file:
+            download_to_file_obj(temp_file, url)
+            temp_file.flush()
+            zf = ZipFile(temp_file.name)
+            zf.extractall(to_dir)
+
+        os.chmod(os.path.join(to_dir, self.executable_path), 0o755)


### PR DESCRIPTION
Probably need more love around executable bits, but this works.