### PR TITLE
Build on 18.04 machines to get older GLIBC symbols on the linux binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-18.04
             asset: ozy-linux
           - os: macos-10.15
             asset: ozy-osx

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-18.04
             asset: ozy-linux
           - os: macos-10.15
             asset: ozy-osx
@@ -38,7 +38,7 @@ jobs:
 
   upload:
     needs: [ build ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v2

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # ozy release notes
 
+## 0.0.9
+* Build linux on Ubuntu 18.04 so we can run the release binaries on Ubuntu 18.04
+
 ## 0.0.8
 * Add support for `pyinstaller`-compressed `conda` binaries. Set `pyinstaller: True` to have `ozy` install the conda binary in a temporary place, then squash it with pyinstaller, and use the squashed version instead.
 

--- a/ozy/__init__.py
+++ b/ozy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.8'
+__version__ = '0.0.9'
 import logging
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
0.0.8 release is broken on older linux distributions. Let's switch to building on slightly older ones.