### PR TITLE
Add info subcommand

### DIFF
--- a/rozy/src/app.rs
+++ b/rozy/src/app.rs
@@ -221,6 +221,18 @@ impl PartialEq for App {
 
 impl Eq for App {}
 
+impl std::fmt::Display for App {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{} {}: {}",
+            self.name,
+            self.version,
+            self.installer.describe()
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use serde_yaml::Mapping;


### PR DESCRIPTION
Produces the following path warning:

```
--------------------------------------------------------------------------------
Please ensure '/home/tlu/.ozy/bin' is on your path
bash shell users:
  bash$ echo -e '# ozy support\nexport PATH=/home/tlu/.ozy/bin:$PATH' >> ~/.bashrc
  then restart your shell sessions
zsh shell users:
  zsh$ # path+=(/home/tlu/.ozy/bin)\nexport PATH
fish shell users: 
  fish$ set --universal fish_user_paths /home/tlu/.ozy/bin $fish_user_paths
--------------------------------------------------------------------------------
```

and the `ozy info` output:

```
Team URL: [redacted]
Team config name: Aquatic Team Configuration
  anaconda-project, 0.8.3: conda installer for anaconda-project=0.8.3
  ansible, 2.9.2: pip installer for ansible=2.9.2
  [and so on]
```

also changes `list` to print to stdout