### PR TITLE
Ensure the path contains the Ozy bin directory when running anything through Ozy

### DIFF
--- a/rozy/src/app.rs
+++ b/rozy/src/app.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Error, Result};
 use file_lock::{FileLock, FileOptions};
 
 use crate::config::{apply_overrides, load_config, resolve};
-use crate::files::{delete_if_exists, get_ozy_cache_dir};
+use crate::files::{check_path, delete_if_exists, get_ozy_bin_dir, get_ozy_cache_dir};
 use crate::installers::conda::Conda;
 use crate::installers::file::File;
 use crate::installers::installer::Installer;
@@ -137,6 +137,12 @@ impl App {
     fn ensure_installed_internal(&self) -> Result<()> {
         if self.is_installed().context("Checking if it's installed")? {
             return Ok(());
+        }
+
+        let ozy_bin_dir = get_ozy_bin_dir()?;
+        if !check_path(&ozy_bin_dir)? {
+            let updated_path = format!("{}:{}", ozy_bin_dir.display(), std::env::var("PATH")?);
+            std::env::set_var("PATH", updated_path);
         }
 
         let install_dir = self.get_install_path()?;

--- a/rozy/src/main.rs
+++ b/rozy/src/main.rs
@@ -151,6 +151,12 @@ fn clean() -> Result<()> {
 }
 
 fn run(app_name: &String, version: &Option<String>, args: &[String]) -> Result<()> {
+    let ozy_bin_dir = files::get_ozy_bin_dir()?;
+    if !check_path(&ozy_bin_dir)? {
+        let updated_path = format!("{}:{}", ozy_bin_dir.display(), std::env::var("PATH")?);
+        std::env::set_var("PATH", updated_path);
+    }
+
     let app = app::find_app(app_name, version)?;
     app.ensure_installed()
         .with_context(|| format!("While ensuring that app {} is installed", app_name))?;

--- a/rozy/src/main.rs
+++ b/rozy/src/main.rs
@@ -151,12 +151,6 @@ fn clean() -> Result<()> {
 }
 
 fn run(app_name: &String, version: &Option<String>, args: &[String]) -> Result<()> {
-    let ozy_bin_dir = files::get_ozy_bin_dir()?;
-    if !check_path(&ozy_bin_dir)? {
-        let updated_path = format!("{}:{}", ozy_bin_dir.display(), std::env::var("PATH")?);
-        std::env::set_var("PATH", updated_path);
-    }
-
     let app = app::find_app(app_name, version)?;
     app.ensure_installed()
         .with_context(|| format!("While ensuring that app {} is installed", app_name))?;


### PR DESCRIPTION
Tested by removing `~/.ozy/bin/` from my path and running a binary which activated the conda installer. 

On main, this produces:

```
Running conda installer for [binary]
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/installers/installer.rs:28:38
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
And on this branch it works. 