### PR TITLE
Check path unconditionally

### DIFF
--- a/rozy/src/app.rs
+++ b/rozy/src/app.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Error, Result};
 use file_lock::{FileLock, FileOptions};
 
 use crate::config::{apply_overrides, load_config, resolve};
-use crate::files::{check_path, delete_if_exists, get_ozy_bin_dir, get_ozy_cache_dir};
+use crate::files::{delete_if_exists, get_ozy_cache_dir};
 use crate::installers::conda::Conda;
 use crate::installers::file::File;
 use crate::installers::installer::Installer;
@@ -137,12 +137,6 @@ impl App {
     fn ensure_installed_internal(&self) -> Result<()> {
         if self.is_installed().context("Checking if it's installed")? {
             return Ok(());
-        }
-
-        let ozy_bin_dir = get_ozy_bin_dir()?;
-        if !check_path(&ozy_bin_dir)? {
-            let updated_path = format!("{}:{}", ozy_bin_dir.display(), std::env::var("PATH")?);
-            std::env::set_var("PATH", updated_path);
         }
 
         let install_dir = self.get_install_path()?;

--- a/rozy/src/main.rs
+++ b/rozy/src/main.rs
@@ -151,6 +151,12 @@ fn clean() -> Result<()> {
 }
 
 fn run(app_name: &String, version: &Option<String>, args: &[String]) -> Result<()> {
+    let ozy_bin_dir = get_ozy_bin_dir()?;
+    if !check_path(&ozy_bin_dir)? {
+        let updated_path = format!("{}:{}", ozy_bin_dir.display(), std::env::var("PATH")?);
+        std::env::set_var("PATH", updated_path);
+    }
+
     let app = app::find_app(app_name, version)?;
     app.ensure_installed()
         .with_context(|| format!("While ensuring that app {} is installed", app_name))?;

--- a/rozy/src/main.rs
+++ b/rozy/src/main.rs
@@ -104,7 +104,11 @@ fn install_all() -> Result<()> {
     Ok(())
 }
 
-fn makefile_config_internal(makefile_var: &String, app_names: &[String], did_path_contain_ozy: bool) -> Result<String> {
+fn makefile_config_internal(
+    makefile_var: &String,
+    app_names: &[String],
+    did_path_contain_ozy: bool,
+) -> Result<String> {
     if !did_path_contain_ozy {
         return Err(anyhow!("The Ozy bin directory must be in the PATH"));
     }

--- a/rozy/src/main.rs
+++ b/rozy/src/main.rs
@@ -113,7 +113,6 @@ fn makefile_config_internal(
         return Err(anyhow!("The Ozy bin directory must be in the PATH"));
     }
 
-    files::ensure_ozy_dirs()?;
     let config = config::load_config(None)?;
 
     let ozy_bin_dir = get_ozy_bin_dir()?;
@@ -449,6 +448,7 @@ the relevant symlinks are created in your ozy bin directory.
 }
 
 fn main() -> Result<(), Error> {
+    files::ensure_ozy_dirs()?;
     let ozy_bin_dir = get_ozy_bin_dir()?;
     let did_path_contain_ozy = check_path(&ozy_bin_dir)?;
     if !did_path_contain_ozy {

--- a/rozy/src/main.rs
+++ b/rozy/src/main.rs
@@ -334,7 +334,11 @@ fn show_path_warning() -> Result<()> {
     Ok(())
 }
 
-fn info() -> Result<()> {
+fn info(did_path_contain_ozy: bool) -> Result<()> {
+    if !did_path_contain_ozy {
+        show_path_warning()?;
+    }
+
     let user_config = config::get_ozy_user_conf()?;
     let team_url = match user_config.get("url") {
         Some(v) => v.as_str().unwrap(),
@@ -459,17 +463,13 @@ fn main() -> Result<(), Error> {
 
     if invoked_as.starts_with("ozy") {
         let args = Args::parse();
-        if !did_path_contain_ozy {
-            show_path_warning()?;
-        }
-
         let exe_path = std::env::current_exe()?;
         match &args.command {
             Commands::Clean => clean(),
             Commands::Init { url } => init(&exe_path, url),
             Commands::Install { app_names } => install(app_names),
             Commands::InstallAll => install_all(),
-            Commands::Info => info(),
+            Commands::Info => info(did_path_contain_ozy),
             Commands::List => list(),
             Commands::MakefileConfig {
                 makefile_var,

--- a/rozy/src/main.rs
+++ b/rozy/src/main.rs
@@ -443,6 +443,10 @@ the relevant symlinks are created in your ozy bin directory.
 fn main() -> Result<(), Error> {
     let ozy_bin_dir = get_ozy_bin_dir()?;
     let did_path_contain_ozy = check_path(&ozy_bin_dir)?;
+    if !did_path_contain_ozy {
+        let updated_path = format!("{}:{}", ozy_bin_dir.display(), std::env::var("PATH")?);
+        std::env::set_var("PATH", updated_path);
+    }
 
     let invoked_as = std::env::args()
         .next()
@@ -480,11 +484,6 @@ fn main() -> Result<(), Error> {
             Commands::Sync => sync(&exe_path),
         }
     } else {
-        if !did_path_contain_ozy {
-            let updated_path = format!("{}:{}", ozy_bin_dir.display(), std::env::var("PATH")?);
-            std::env::set_var("PATH", updated_path);
-        }
-
         let args = std::env::args().collect::<Vec<String>>();
         run(&invoked_as, &None, &args[1..])
     }

--- a/rozy/src/main.rs
+++ b/rozy/src/main.rs
@@ -104,7 +104,11 @@ fn install_all() -> Result<()> {
     Ok(())
 }
 
-fn makefile_config_internal(makefile_var: &String, app_names: &[String]) -> Result<String> {
+fn makefile_config_internal(makefile_var: &String, app_names: &[String], did_path_contain_ozy: bool) -> Result<String> {
+    if !did_path_contain_ozy {
+        return Err(anyhow!("The Ozy bin directory must be in the PATH"));
+    }
+
     files::ensure_ozy_dirs()?;
     let config = config::load_config(None)?;
 
@@ -136,11 +140,7 @@ fn makefile_config(
     app_names: &[String],
     did_path_contain_ozy: bool,
 ) -> Result<()> {
-    if !did_path_contain_ozy {
-        return Err(anyhow!("In order to create a Makefile config, please ensure that the Ozy bin dir is in the PATH"));
-    }
-
-    match makefile_config_internal(makefile_var, app_names) {
+    match makefile_config_internal(makefile_var, app_names, did_path_contain_ozy) {
         Ok(str) => {
             println!("{}", str);
         }


### PR DESCRIPTION
@apmorton pointed out that setting the environment variable only when the app is being installed means that the environment provided to the app will be different in the first invocation vs. later ones. 