### PR TITLE
Add support for automatic team config updates

### DIFF
--- a/rozy/src/app.rs
+++ b/rozy/src/app.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Error, Result};
 use file_lock::{FileLock, FileOptions};
 
-use crate::config::{apply_overrides, load_config, resolve};
+use crate::config::{apply_overrides, resolve};
 use crate::files::{delete_if_exists, get_ozy_cache_dir};
 use crate::installers::conda::Conda;
 use crate::installers::file::File;
@@ -30,12 +30,7 @@ pub struct App {
     executable_path: String,
 }
 
-pub fn find_app(app: &String, version: &Option<String>) -> Result<App> {
-    if version.is_some() {
-        return Err(anyhow!("find_app w/ version not implemented"));
-    }
-
-    let config = load_config(None).context("While loading ozy config")?;
+pub fn find_app(config: &serde_yaml::Mapping, app: &String) -> Result<App> {
     App::new(app, &config)
         .with_context(|| format!("While attempting to find the app {} to run", app))
 }
@@ -128,10 +123,6 @@ impl App {
         }
 
         result
-    }
-
-    pub fn delete(&self) -> Result<()> {
-        delete_if_exists(self.get_install_path()?.as_path())
     }
 
     fn ensure_installed_internal(&self) -> Result<()> {

--- a/rozy/src/config.rs
+++ b/rozy/src/config.rs
@@ -1,8 +1,12 @@
 use crate::files::get_ozy_dir;
 use anyhow::{Context, Result};
-use std::collections::HashMap;
+use std::{collections::HashMap, time::SystemTime};
 
 use serde_yaml::Mapping as Config;
+
+pub fn config_mtime() -> Result<SystemTime> {
+    return Ok(std::fs::metadata(&get_ozy_dir()?.join("ozy.yaml"))?.modified().unwrap());
+}
 
 pub fn load_config(base_config_filename_override: Option<&str>) -> Result<Config> {
     let mut curr_config = parse_ozy_config(


### PR DESCRIPTION
I was able to test that this indeed does the correct thing in all cases.

- `ozy update` when a binary update is required
- `ozy update` when a binary update is not required
- `ninja --version 2>/dev/null` when no update should happen
- `ninja --version 2>/dev/null` when an update is expected, but no binary update
- `ninja --version 2>/dev/null` when an update is expected, and a binary update needs to happen