### PR TITLE
Use is_file instead of existence in finding .ozy.yaml

### DIFF
--- a/rozy/src/config.rs
+++ b/rozy/src/config.rs
@@ -19,7 +19,7 @@ pub fn load_config(base_config_filename_override: Option<&str>) -> Result<Config
     let ancestors: Vec<&std::path::Path> = curr_dir.ancestors().collect();
     for dir in ancestors.iter().rev() {
         let ozy_config_path = dir.join(".ozy.yaml");
-        if !ozy_config_path.exists() {
+        if !ozy_config_path.is_file() {
             continue;
         }
 


### PR DESCRIPTION
Fixes an issue where if you have a magic filesystem on your cwd (e.g. `envy` via autofs) which dreams up directories if you ask it ...then `ozy` used to:

```
Error: While loading ozy config

Caused by:
    0: Reading config YAML
    1: Is a directory (os error 21)
```