### PR TITLE
Support a pinned python version for pip packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "ozy"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ozy"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/app.rs
+++ b/src/app.rs
@@ -312,6 +312,17 @@ mod tests {
     }
 
     #[test]
+    fn pip_pinned_test() {
+        let config = get_test_config();
+        let pip_app =
+            App::new(&"pip_app_pinned".to_string(), &config).expect("Failed to construct App");
+        assert_eq!(
+            pip_app.installer.describe(),
+            "pip installer for pip_package=1.20.4"
+        );
+    }
+
+    #[test]
     fn conda_test() {
         let config = get_test_config();
         let conda_app =

--- a/src/installers/pip.rs
+++ b/src/installers/pip.rs
@@ -7,6 +7,7 @@ pub struct Pip {
     version: String,
     channels: Vec<String>,
     env: Vec<(String, String)>,
+    python_version: Option<String>,
 }
 
 impl Pip {
@@ -34,11 +35,19 @@ impl Pip {
             _ => vec![],
         };
 
+        let python_version = match app_config.get("python_version") {
+            Some(serde_yaml::Value::String(v)) => Some(v.to_string()),
+            Some(serde_yaml::Value::Null) => None,
+            Some(_) => None,
+            None => None,
+        };
+
         Ok(Pip {
             package,
             version: version.to_string(),
             channels,
             env,
+            python_version,
         })
     }
 }
@@ -48,11 +57,16 @@ impl Installer for Pip {
         eprintln!("Running {}", self.describe());
         std::fs::create_dir_all(to_dir)?;
 
+        let to_install = match &self.python_version {
+            Some(v) => vec![format!("python={}", v.clone()), String::from("pip")],
+            None => vec![String::from("pip")],
+        };
+
         conda_install(
             &String::from("conda"),
             &self.channels,
             to_dir,
-            &[String::from("pip")],
+            to_install.as_slice(),
             &self.env,
         )?;
 

--- a/test_resource/unittest.ozy.yaml
+++ b/test_resource/unittest.ozy.yaml
@@ -36,6 +36,12 @@ apps:
     type: pip
     package: pip_package
     executable_path: bin/pip_app
+  pip_app_pinned:
+    version: 1.20.4
+    type: pip
+    package: pip_package
+    executable_path: bin/pip_app
+    python_version: "3.13"
   conda_app:
     version: '45'
     type: conda


### PR DESCRIPTION
Adds a `python_version` directive to `pip` apps which instructs the conda installer to use a specific python version when creating the base python environment for the app.